### PR TITLE
Resolve Unknown Component 'markup://c:resultTable' error

### DIFF
--- a/force-app/main/default/lwc/resultTable/resultTable.js-meta.xml
+++ b/force-app/main/default/lwc/resultTable/resultTable.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
-    <isExposed>false</isExposed>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>


### PR DESCRIPTION
While using this component, I was running into the aforementioned error. The resolution was to make the component exposed.